### PR TITLE
Mask pixels in result analysis

### DIFF
--- a/beam_telescope_analysis/converter/pybar_fei4_converter.py
+++ b/beam_telescope_analysis/converter/pybar_fei4_converter.py
@@ -151,4 +151,4 @@ if __name__ == "__main__":
     # Single file processing
     # Input raw data filename
     # raw_data_file = 'pybar_raw_data.h5'
-    # process_dut(input_file=raw_data_file, trigger_data_format=trigger_data_format)
+    # process_dut(raw_data_file=raw_data_file, trigger_data_format=trigger_data_format)

--- a/beam_telescope_analysis/converter/pymosa_converter.py
+++ b/beam_telescope_analysis/converter/pymosa_converter.py
@@ -134,4 +134,4 @@ if __name__ == "__main__":
     # Single file processing
     # Input raw data filename
     raw_data_file = 'pymosa_raw_data.h5'
-    process_dut(input_file=raw_data_file, trigger_data_format=2)
+    process_dut(raw_data_file=raw_data_file, trigger_data_format=2)

--- a/beam_telescope_analysis/track_analysis.py
+++ b/beam_telescope_analysis/track_analysis.py
@@ -839,7 +839,7 @@ def fit_tracks(telescope_configuration, input_track_candidates_file, output_trac
                     # NOTE: this value has a significant impact on CPU processing time
                     if method == "kalman":
                         # increase minimum track hits requirement for Kalman fit to reduce CPU processing time
-                        select_fit_tracks = (analysis_utils.number_of_set_bits(track_candidates_chunk['hit_flag'] & dut_fit_mask) >= min(3, actual_min_track_hits))
+                        select_fit_tracks = (analysis_utils.number_of_set_bits(track_candidates_chunk['hit_flag'] & dut_fit_mask) >= max(3, actual_min_track_hits))
                     else:
                         select_fit_tracks = (analysis_utils.number_of_set_bits(track_candidates_chunk['hit_flag'] & dut_fit_mask) >= 2)
                     # Select tracks that will be stored


### PR DESCRIPTION
This PR adds the ability to mask pixels in the final result analysis (efficiency calculation, ..).
A mask (`boolean` array) can be passed to `result_analysis()` such that every masked pixel is excluded from the final analysis.

- [ ] Add mask plot to pdf
- [ ] More documentation: Mask is applied to **everything**!

Further: two small bugs are fixed.