### PR TITLE
Maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Cython-generated CPP file
+beam_telescope_analysis/cpp/analysis_functions.cpp

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ sudo apt install git-lfs
 
 Alternatively, manually install `git lfs` using [these](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage) instructions.
 
+The `setup.py` requires that `cython`, `numpy` and `gcc` are already installed. Therefore, use e.g. `conda` or `pip`
+```
+conda install -y cython numpy
+```
+
+Furthermore, if `gcc` is not installed, run
+```
+sudo apt install build-essential
+``` 
 
 ### Installation of BTA
 


### PR DESCRIPTION
This PR

- Updates the README install instructions to work on with a fresh install / Python env because `setup.py` relies on `cython`, `numpy` and `gcc` 
- Adds the Cython output CPP to the .gitignore 